### PR TITLE
handle Gemfile failures

### DIFF
--- a/lib/double_doc/import_handler.rb
+++ b/lib/double_doc/import_handler.rb
@@ -1,5 +1,6 @@
 require 'pathname'
 require 'double_doc/doc_extractor'
+require 'bundler'
 
 module DoubleDoc
   class ImportHandler


### PR DESCRIPTION
If unbundled, Bundler dies with a NoMethodError that I don't care to track down fully.

@staugaard
