### PR TITLE
Create doubledoc client

### DIFF
--- a/lib/double_doc.rb
+++ b/lib/double_doc.rb
@@ -1,2 +1,3 @@
 require "double_doc/version"
 require "double_doc/task"
+require "double_doc/client"

--- a/lib/double_doc/client.rb
+++ b/lib/double_doc/client.rb
@@ -1,0 +1,67 @@
+require 'double_doc/import_handler'
+require 'double_doc/html_generator'
+
+module DoubleDoc
+  class Client
+    attr_reader :md_sources, :options
+
+    def initialize(md_sources, options = {})
+      @md_sources = [md_sources].flatten
+      @options = options
+    end
+
+    def process
+      sources = md_sources.map do |source|
+        if source.to_s =~ /\*/
+          import_handler.load_paths.map do |path|
+            Dir.glob(File.join(path, source))
+          end
+        else
+          import_handler.find_file(source).path
+        end
+      end.flatten.uniq
+
+      generated_md_files = []
+
+      md_dst = Pathname.new(options[:md_destination])
+      system('mkdir', '-p', md_dst.to_s)
+      sources.each do |src|
+        next if File.directory?(src)
+        dst = md_dst + File.basename(src)
+        puts "#{src} -> #{dst}" unless options[:quiet]
+
+        if src.to_s =~ /\.md$/
+          body = import_handler.resolve_imports(File.new(src))
+        else
+          body = File.read(src)
+        end
+
+        File.open(dst, 'w') do |out|
+          out.write(body)
+        end
+
+        generated_md_files << dst
+      end
+
+      args = options[:args] || {}
+      html_dst = Pathname.new(options[:html_destination]) if options[:html_destination]
+      if html_dst || args[:html_destination]
+        html_generator = DoubleDoc::HtmlGenerator.new(generated_md_files, options.merge(args))
+        html_generator.generate
+      end
+
+      sources
+    end
+
+    private
+
+    def import_handler
+      return @import_handler if defined?(@import_handler)
+
+      roots = options[:roots] || [File.dirname(__FILE__)]
+      import_options = options.fetch(:import, {})
+      roots << { :quiet => options[:quiet] }.merge(import_options)
+      @import_handler = DoubleDoc::ImportHandler.new(*roots)
+    end
+  end
+end

--- a/lib/double_doc/html_generator.rb
+++ b/lib/double_doc/html_generator.rb
@@ -14,6 +14,7 @@ module DoubleDoc
       @html_renderer = options[:html_renderer] || HtmlRenderer
       @stylesheet = options[:html_css] || DEFAULT_CSS
       @title = options[:title] || 'Documentation'
+      @quiet = options[:quiet] == true
       @exclude_from_navigation = options[:exclude_from_navigation] || []
     end
 
@@ -32,7 +33,7 @@ module DoubleDoc
         end
 
         dst = @output_directory + path
-        puts "#{src} -> #{dst}"
+        puts "#{src} -> #{dst}" unless @quiet
         FileUtils.mkdir_p(File.dirname(dst))
 
         if from_markdown

--- a/lib/double_doc/import_handler.rb
+++ b/lib/double_doc/import_handler.rb
@@ -11,6 +11,7 @@ module DoubleDoc
       options ||= {}
 
       @load_paths = roots.map {|root| Pathname.new(root)}
+      @quiet = options[:quiet] == true
 
       if options[:gemfile]
         begin
@@ -59,7 +60,7 @@ module DoubleDoc
       end
 
       with_gemfile(gemfile) do
-        puts "Loading paths from #{gemfile}"
+        puts "Loading paths from #{gemfile}" unless @quiet
 
         defn = Bundler::Definition.build(gemfile, root + "Gemfile.lock", nil)
         defn.validate_ruby!

--- a/lib/double_doc/task.rb
+++ b/lib/double_doc/task.rb
@@ -60,11 +60,8 @@ module DoubleDoc
 
       desc "Generate markdown #{html_dst ? 'and HTML ' : ''}DoubleDoc documentation"
       generated_task = task(task_name => destinations) do |t, args|
-        client = DoubleDoc::Client.new(options[:sources], options.merge({
-          :roots => roots,
-          :args => args
-        }))
-
+        opts = args.merge(options.merge(:roots => roots))
+        client = DoubleDoc::Client.new(options[:sources], opts)
         client.process
       end
 

--- a/lib/double_doc/task.rb
+++ b/lib/double_doc/task.rb
@@ -1,8 +1,7 @@
 require 'rake'
 require 'pathname'
 require 'tmpdir'
-require 'double_doc/import_handler'
-require 'double_doc/html_generator'
+require 'double_doc/client'
 
 module DoubleDoc
 
@@ -48,7 +47,6 @@ module DoubleDoc
     include Rake::DSL if defined?(Rake::DSL)
 
     def initialize(task_name, options)
-      md_srcs  = [options[:sources]].flatten
       md_dst   = Pathname.new(options[:md_destination])
       html_dst = Pathname.new(options[:html_destination]) if options[:html_destination]
 
@@ -57,48 +55,17 @@ module DoubleDoc
         directory(dst.to_s)
       end
 
+      roots = Array(options[:root])
+      roots << Rake.original_dir if roots.empty?
+
       desc "Generate markdown #{html_dst ? 'and HTML ' : ''}DoubleDoc documentation"
       generated_task = task(task_name => destinations) do |t, args|
-        roots = Array(options[:root])
-        roots << Rake.original_dir if roots.empty?
-        roots << options.fetch(:import, {})
+        client = DoubleDoc::Client.new(options[:sources], options.merge({
+          :roots => roots,
+          :args => args
+        }))
 
-        import_handler = DoubleDoc::ImportHandler.new(*roots)
-
-        sources = md_srcs.map do |source|
-          if source =~ /\*/
-            import_handler.load_paths.map do |path|
-              Dir.glob(File.join(path, source))
-            end
-          else
-            import_handler.find_file(source).path
-          end
-        end.flatten.uniq
-
-        generated_md_files = []
-
-        sources.each do |src|
-          dst = md_dst + File.basename(src)
-          puts "#{src} -> #{dst}"
-
-          if src.to_s =~ /\.md$/
-            body = import_handler.resolve_imports(File.new(src))
-          else
-            body = File.read(src)
-          end
-
-          File.open(dst, 'w') do |out|
-            out.write(body)
-          end
-
-          generated_md_files << dst
-        end
-
-        if html_dst || args[:html_destination]
-          html_generator = DoubleDoc::HtmlGenerator.new(generated_md_files, options.merge(args))
-          html_generator.generate
-        end
-
+        client.process
       end
 
       has_github_pages = !`git branch | grep 'gh-pages'`.empty? rescue false

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+describe "import handler" do
+  subject do
+    DoubleDoc::Client.new(sources, options)
+  end
+
+  describe '#process' do
+    let(:destination) { Dir.mktmpdir }
+    let(:sources) { [Bundler.root + 'doc/readme.md'] }
+    let(:options) { { :md_destination => destination, :roots => [Bundler.root], :quiet => true } }
+
+    before do
+      subject.process
+    end
+
+    it 'produces output at the md_destination' do
+      File.exists?(destination + '/readme.md').must_equal true
+    end
+
+    describe 'with a missing directory' do
+      let(:destination) { Dir.mktmpdir + '/tmp' }
+
+      it 'creates the directory' do
+        File.exists?(destination + '/readme.md').must_equal true
+      end
+    end
+
+    describe 'with multiple sources' do
+      let(:sources) { %w(readme todo).map{|f| Bundler.root + "doc/#{f}.md" } }
+
+      it 'processes all sources' do
+        File.exists?(destination + '/readme.md').must_equal true
+        File.exists?(destination + '/todo.md').must_equal true
+      end
+    end
+
+    describe 'producing html' do
+      let(:options) { {
+        :md_destination => destination,
+        :html_destination => destination + '/html',
+        :roots => [Bundler.root],
+        :quiet => true
+      } }
+
+      it 'creates html files' do
+        File.exists?(destination + '/html/readme.html').must_equal true
+      end
+    end
+  end
+end

--- a/test/html_generator_test.rb
+++ b/test/html_generator_test.rb
@@ -10,7 +10,10 @@ describe "the html generator" do
     @output_file_name = @destination + 'input.html'
     Dir.mkdir(@root + 'source')
     Dir.mkdir(@destination)
-    @generator = DoubleDoc::HtmlGenerator.new([@input_file_name], { :html_destination => @destination })
+    @generator = DoubleDoc::HtmlGenerator.new([@input_file_name], {
+      :html_destination => @destination,
+      :quiet => true
+    })
   end
 
   after do
@@ -63,7 +66,8 @@ describe "the html generator" do
 
     it "should generate links for each page in the navigation area" do
       generator = DoubleDoc::HtmlGenerator.new(@input_files, {
-        :html_destination => @destination
+        :html_destination => @destination,
+        :quiet => true
       })
       generator.generate
 
@@ -76,7 +80,8 @@ describe "the html generator" do
     it "should skip specified filed" do
       generator = DoubleDoc::HtmlGenerator.new(@input_files, {
         :html_destination => @destination,
-        :exclude_from_navigation => ['file_two.html']
+        :exclude_from_navigation => ['file_two.html'],
+        :quiet => true
       })
       generator.generate
 

--- a/test/import_handler_test.rb
+++ b/test/import_handler_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe "import handler" do
   subject do
-    roots = Array(root).push(options)
+    roots = Array(root).push(options.merge( :quiet => true ))
     DoubleDoc::ImportHandler.new(*roots)
   end
 


### PR DESCRIPTION
I'd like to use DoubleDoc programmatically which I can't do while the process logic is in the task generation. This PR extracts the logic into a `Client` class which could be used to process doubledoc format without running through rake.

@staugaard @steved 