### PR TITLE
allow for linebreaks in source files to be ignored in generated docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
+sudo: false
 rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.1
 branches:
   except:
     - gh-pages
+before_install:
+  - gem update --system
+  - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "mime-types", :git => "https://github.com/halostatue/mime-types.git", :ref => "v1.22"
+  gem "mime-types", :git => "https://github.com/mime-types/ruby-mime-types.git", :ref => "v1.22"
 end

--- a/lib/double_doc/doc_extractor.rb
+++ b/lib/double_doc/doc_extractor.rb
@@ -1,8 +1,8 @@
 module DoubleDoc
   class DocExtractor
     TYPES = {
-      'rb' => /\s*##\s?(.*)$/,
-      'js' => %r{\s*///\s?(.*)$}
+      'rb' => /\s*##\s?(.*?)(\\?)$/,
+      'js' => %r{\s*///\s?(.*?)(\\?)$}
       }.freeze
 
     def self.extract(source, options = {})
@@ -28,13 +28,20 @@ module DoubleDoc
       extractor = TYPES[options[:type]]
 
       add_empty_line = false
+      append_to_previous = false
       lines.each do |line|
         if match = line.match(extractor)
           if add_empty_line
             doc << ''
             add_empty_line = false
           end
-          doc << match[1].rstrip
+          new_string = match[1].rstrip
+          if append_to_previous
+            doc[-1] << new_string
+          else
+            doc << new_string
+          end
+          append_to_previous = !match[2].empty?
         else
           add_empty_line = !doc.empty?
         end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -15,14 +15,14 @@ describe "import handler" do
     end
 
     it 'produces output at the md_destination' do
-      File.exists?(destination + '/readme.md').must_equal true
+      File.exist?(destination + '/readme.md').must_equal true
     end
 
     describe 'with a missing directory' do
       let(:destination) { Dir.mktmpdir + '/tmp' }
 
       it 'creates the directory' do
-        File.exists?(destination + '/readme.md').must_equal true
+        File.exist?(destination + '/readme.md').must_equal true
       end
     end
 
@@ -30,8 +30,8 @@ describe "import handler" do
       let(:sources) { %w(readme todo).map{|f| Bundler.root + "doc/#{f}.md" } }
 
       it 'processes all sources' do
-        File.exists?(destination + '/readme.md').must_equal true
-        File.exists?(destination + '/todo.md').must_equal true
+        File.exist?(destination + '/readme.md').must_equal true
+        File.exist?(destination + '/todo.md').must_equal true
       end
     end
 
@@ -44,7 +44,7 @@ describe "import handler" do
       } }
 
       it 'creates html files' do
-        File.exists?(destination + '/html/readme.html').must_equal true
+        File.exist?(destination + '/html/readme.html').must_equal true
       end
     end
   end

--- a/test/doc_extractor_test.rb
+++ b/test/doc_extractor_test.rb
@@ -14,11 +14,15 @@ describe "the doc extractor" do
 
     it "doesn't add any extra new-lines" do
       subject.must_match(/^this/m)
-      subject.must_match(/extracted\n$/m)
+      subject.must_match(/this one.\n$/m)
     end
 
     it "adds an empty line between documentation sections" do
       subject.must_match(/extracted\n\nthis/m)
+    end
+
+    it "concatenates lines that end in a backslash" do
+      subject.must_match(/this line should be concatenated to...this one./)
     end
   end
 
@@ -26,6 +30,8 @@ describe "the doc extractor" do
     ## this line should be extracted
     # this line should not be extracted
     ## this line should also be extracted
+    ## this line should be concatenated to...\
+    ## this one.
 
     subject do
       DoubleDoc::DocExtractor.extract(File.new(__FILE__))
@@ -40,6 +46,8 @@ describe "the doc extractor" do
         /// this line should be extracted
         // this line should not be extracted
         /// this line should also be extracted
+        /// this line should be concatenated to...\\
+        /// this one.
       EOS
       DoubleDoc::DocExtractor.extract(source, :type => 'js')
     end

--- a/test/doc_extractor_test.rb
+++ b/test/doc_extractor_test.rb
@@ -14,7 +14,7 @@ describe "the doc extractor" do
 
     it "doesn't add any extra new-lines" do
       subject.must_match(/^this/m)
-      subject.must_match(/this one.\n$/m)
+      subject.must_match(/this one\.\n$/m)
     end
 
     it "adds an empty line between documentation sections" do
@@ -22,7 +22,7 @@ describe "the doc extractor" do
     end
 
     it "concatenates lines that end in a backslash" do
-      subject.must_match(/this line should be concatenated to...this one./)
+      subject.must_match(/this line should be concatenated to...this one\./)
     end
   end
 


### PR DESCRIPTION
When a line of documentation ends in a backslash the following line will be appended to it.

My usecase is a repo that uses [cane](https://github.com/square/cane/), which is complaining about long lines of documentation. Since cane doesn't know about programming languages I can't get it to ignore commented out lines, so this seems like the best place to resolve it.

@staugaard thoughts?