### PR TITLE
compatibility with Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 cache: bundler
+dist: trusty
 sudo: false
 rvm:
   - 2.0
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4.0
 branches:
   only: master

--- a/double_doc.gemspec
+++ b/double_doc.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "rake"
   s.add_runtime_dependency "erubis"
   s.add_runtime_dependency "redcarpet", "< 4"
-  s.add_runtime_dependency "pygments.rb", "~> 0.2"
+  s.add_runtime_dependency "pygments.rb", "~> 1.1.1"
 end


### PR DESCRIPTION
### Description

Bump a major version of pygments.rb, which introduces unspecified breaking changes from the Python pygments library. This also drops a dependency on `yajl-ruby <~ 1.2.0` which used `Fixnum` in a C extension (this class is gone in ruby 2.4).

cc @zendesk/wombat @zendesk/vegemite 

### Risks

- [high] since there are breaking changes in the syntax highlighter we should verify it against our styling before shipping this to production