### PR TITLE
Update required pygments version to 1.2

### DIFF
--- a/double_doc.gemspec
+++ b/double_doc.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "rake"
   s.add_runtime_dependency "erubis"
   s.add_runtime_dependency "redcarpet", "< 4"
-  s.add_runtime_dependency "pygments.rb", "~> 0.2"
+  s.add_runtime_dependency "pygments.rb", "~> 1.2"
 end


### PR DESCRIPTION
There is a high severity security vulnerability in the version of yajl used by pygments 0.2. This PR updates the version of pygments used to version ~> 1.2 in order to pull in the fix to the vulnerability. 