### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,26 @@
-name: Publish public gem
+name: Publish to RubyGems.org
 
 on:
   push:
-    tags: v*
+    branches: main
+    paths: lib/double_doc/version.rb
+  workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
-    secrets:
-      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
-      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+          
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/readme.md
+++ b/readme.md
@@ -102,12 +102,20 @@ If a gh-pages branch exists, run `rake doc:publish` to generate html documentati
  - Tested on ruby 3.0+
  - Does not work on jruby because of its dependency on redcarpet.
 
-### Release
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. run `bundle lock` to update `Gemfile.lock`,
+3. merge this change into `main`, and
+4. look at [the action](https://github.com/zendesk/double_doc/actions/workflows/publish.yml) for output.
 
-After merging your changes:
-1. Create a PR with a version bump and updated changelog.
-2. After that PR gets merged, create a new tag (by running `gem_push=no rake release` or via Github releases).
-3. This will trigger the publishing workflow—[approve it in Github Actions](https://github.com/zendesk/double_doc/actions/workflows/publish.yml)).
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/double_doc/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
 
 ### TODO
 * Support for directory structures


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Setting `ENV["gem_push"]` is also not necessary anymore.

`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [x] Release description has been updated correctly.